### PR TITLE
Add functions for multiplicating and dividing pixel scale

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,7 +5,7 @@
   "fixed": [],
   "linked": [],
   "access": "public",
-  "baseBranch": "master",
+  "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []
 }

--- a/.changeset/good-parrots-study.md
+++ b/.changeset/good-parrots-study.md
@@ -1,0 +1,5 @@
+---
+'pixel-scale': minor
+---
+
+Add `multiplyPixelScale` and `dividePixelScale` functions to simplify up- and downscaling.

--- a/.changeset/silent-cheetahs-pull.md
+++ b/.changeset/silent-cheetahs-pull.md
@@ -1,0 +1,5 @@
+---
+'pixel-scale': minor
+---
+
+Make `options` parameter optional.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Up- or downscales an image to the specified scale, without losing quality or cha
 
 - `to` (number) - The desired scale of the new image.
 
-- `options` (object)
+- `options` (object, optional)
   - `from` (number) - The current scale of the image. If no `from` value is provided, the scale is
     calculated with `getPixelScale`. Only provide a `from` value if you are sure of the current
     pixel scale and want to save time.
@@ -82,7 +82,7 @@ Get the current pixel scale of an image.
 
 - `imageData` (ImageData instance) - The ImageData instance to scale.
 
-- `options` (object)
+- `options` (object, optional)
 
   - `maxColorDiff` (number, default: 0) - A number setting the maximum difference allowed in an
     individual color channel (0-255) when comparing pixels. Useful when getting the pixel scale of

--- a/README.md
+++ b/README.md
@@ -12,18 +12,12 @@
 📐 Get the pixel scale of an image, or scale it up or down without quality loss. Useful for pixel
 art!
 
-All functions operate on [ImageData](https://developer.mozilla.org/en-US/docs/Web/API/ImageData),
-which can be retrieved from a
-[canvas](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas) in the browser or e.g.
-[node-canvas](https://github.com/Automattic/node-canvas) or [sharp](https://github.com/lovell/sharp)
-on Node.
+- 👀 Zero loss of quality
+- 🤖 Auto-detects current scale by default
+- ⏫ Can scale by multiplier or to a specific scale
+- 0️⃣ Zero dependencies
+- 🖼️ Works directly on [ImageData](#imagedata)
 
-The pixel scale referred to in this readme is the amount of times a pixel of e.g. a pixel art image
-has been multiplied to increase the image size. For example,
-[this image](https://github.com/duniul/pixel-scale/blob/master/test/images/pixel-the-cat_x1.png) has
-a pixel scale of 1, while
-[this image](https://github.com/duniul/pixel-scale/blob/master/test/images/pixel-the-cat_x10.png)
-has a pixel scale of 10.
 
 ## Table of contents
 
@@ -34,7 +28,10 @@ has a pixel scale of 10.
   - [`getPixelScale(imageData, options)`](#getpixelscaleimagedata-options)
   - [`multiplyPixelScale(imageData, by, options)`](#multiplypixelscaleimagedata-by-options)
   - [`multiplyPixelScale(imageData, by, options)`](#multiplypixelscaleimagedata-by-options-1)
-- [How does it work?](#how-does-it-work)
+- [About](#about)
+  - [ImageData](#imagedata)
+  - [Pixel scale](#pixel-scale-1)
+  - [How does it work?](#how-does-it-work)
 
 ## Demo
 
@@ -169,7 +166,26 @@ const doubledImageData = dividePixelScale(imageData, 2);
 const tenfoldImageData = dividePixelScale(imageData, 4, { from: 8 });
 ```
 
-## How does it work?
+## About
+
+### ImageData
+
+All functions operate on [ImageData](https://developer.mozilla.org/en-US/docs/Web/API/ImageData),
+which can be retrieved from a
+[canvas](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas) in the browser or e.g.
+[node-canvas](https://github.com/Automattic/node-canvas) or [sharp](https://github.com/lovell/sharp)
+on Node.
+
+### Pixel scale
+
+The pixel scale referred to in this readme is the amount of times a pixel of e.g. a pixel art image
+has been multiplied to increase the image size. For example,
+[this image](https://github.com/duniul/pixel-scale/blob/master/test/images/pixel-the-cat_x1.png) has
+a pixel scale of 1, while
+[this image](https://github.com/duniul/pixel-scale/blob/master/test/images/pixel-the-cat_x10.png)
+has a pixel scale of 10.
+
+### How does it work?
 
 To get the pixel scale of an image, `pixel-scale` first figures out the common divisors of the
 image's height and width. This is done using Euclid's algorithm for finding the greatest common

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
-<img src="https://github.com/duniul/pixel-scale/blob/master/test/images/pixel-the-cat_x1.png" />
-<img src="https://github.com/duniul/pixel-scale/blob/master/test/images/pixel-the-cat_x5.png" />
-<img src="https://github.com/duniul/pixel-scale/blob/master/test/images/pixel-the-cat_x10.png" />
+<img src="https://github.com/duniul/pixel-scale/blob/main/test/images/pixel-the-cat_x1.png" />
+<img src="https://github.com/duniul/pixel-scale/blob/main/test/images/pixel-the-cat_x5.png" />
+<img src="https://github.com/duniul/pixel-scale/blob/main/test/images/pixel-the-cat_x10.png" />
 </p>
 
 # pixel-scale
@@ -24,6 +24,17 @@ has been multiplied to increase the image size. For example,
 a pixel scale of 1, while
 [this image](https://github.com/duniul/pixel-scale/blob/master/test/images/pixel-the-cat_x10.png)
 has a pixel scale of 10.
+
+## Table of contents
+
+- [Demo](#demo)
+- [Installation](#installation)
+- [Usage](#usage)
+  - [`scalePixels(imageData, to, options)`](#scalepixelsimagedata-to-options)
+  - [`getPixelScale(imageData, options)`](#getpixelscaleimagedata-options)
+  - [`multiplyPixelScale(imageData, by, options)`](#multiplypixelscaleimagedata-by-options)
+  - [`multiplyPixelScale(imageData, by, options)`](#multiplypixelscaleimagedata-by-options-1)
+- [How does it work?](#how-does-it-work)
 
 ## Demo
 
@@ -84,15 +95,7 @@ Get the current pixel scale of an image.
 
 - `options` (object, optional)
 
-  - `maxColorDiff` (number, default: 0) - A number setting the maximum difference allowed in an
-    individual color channel (0-255) when comparing pixels. Useful when getting the pixel scale of
-    an image that may contain e.g. JPEG-fragments or color distortions.
-
-    As an example,
-    [this Metal Slug image](https://github.com/duniul/pixel-scale/blob/master/test/images/metal-slug_x24.png)
-    has a pixel scale of 24, but since it has been incorrectly resized and contains some
-    miscolored lines between its scaled pixels it would be detected as having a scale of 1 unless
-    the `maxColorDiff` is increased.
+  - `maxColorDiff` (number, default: 0) - See `scalePixels`'s `maxColorDiff` option.
 
 **Return value:**
 
@@ -109,6 +112,61 @@ const imageScale = getPixelScale(imageData);
 // get an image's pixel scale, allowing a maximum difference of 10 when comparing
 // color channels of individual pixels
 const imageScale = getPixelScale(imageData, { maxColorDiff: 10 });
+```
+
+### `multiplyPixelScale(imageData, by, options)`
+
+Similar to `scalePixels`, but upscales the image by the specified multiplier instead of to a specific scale. Detects the current scale of the image if no `options.from` value is provided.
+
+**Parameters:**
+
+- `imageData` (ImageData instance) - The ImageData instance to upscale.
+
+- `by` (number) - The amount to multiply the image's current scale by.
+
+- `options` (object, optional) - See `scalePixels`'s `options`.
+
+**Return value:**
+
+A new, scaled ImageData-instance.
+
+**Examples:**
+
+```js
+import { multiplyPixelScale } from 'pixel-scale';
+
+// detect an image's current scale, and double it's size
+const doubledImageData = multiplyPixelScale(imageData, 2);
+
+// take an image of scale 5, and multiply it by 10
+const tenfoldImageData = multiplyPixelScale(imageData, 10, { from: 5 });
+```
+
+### `multiplyPixelScale(imageData, by, options)`
+
+Similar to `scalePixels`, but downscales the image by the specified amount of times instead of to a specific scale. Detects the current scale of the image if no `options.from` value is provided.
+**Parameters:**
+
+- `imageData` (ImageData instance) - The ImageData instance to downscale.
+
+- `by` (number) - The amount to divide the image's current scale by.
+
+- `options` (object, optional) - See `scalePixels`'s `options`.
+
+**Return value:**
+
+A new, scaled ImageData-instance.
+
+**Examples:**
+
+```js
+import { dividePixelScale } from 'pixel-scale';
+
+// detect an image's current scale, and make it half as big
+const doubledImageData = dividePixelScale(imageData, 2);
+
+// take an image of scale 8 and divide it by 4
+const tenfoldImageData = dividePixelScale(imageData, 4, { from: 8 });
 ```
 
 ## How does it work?

--- a/biome.json
+++ b/biome.json
@@ -12,6 +12,9 @@
       }
     }
   },
+  "organizeImports": {
+    "enabled": true
+  },
   "formatter": {
     "enabled": true,
     "lineWidth": 100,

--- a/src/getPixelScale.test.ts
+++ b/src/getPixelScale.test.ts
@@ -1,12 +1,12 @@
 import { beforeAll, expect, it } from 'vitest';
-import { getPixelScale } from './getPixelScale.js';
 import {
   getPixelTheCatScale1,
-  getPixelTheCatScale32,
   getPixelTheCatScale5,
+  getPixelTheCatScale32,
   getVectorAvatar,
   getWhiteSquareScale100,
 } from '../test/testImageData.js';
+import { getPixelScale } from './getPixelScale.js';
 
 const imageData: Record<string, ImageData> = {};
 

--- a/src/getPixelScale.ts
+++ b/src/getPixelScale.ts
@@ -1,5 +1,5 @@
 import { findCommonDivisors } from './helpers/commonDivisors.js';
-import { ImageDataLike, ImageDataLikeData, GetPixelScaleOptions } from './types.js';
+import type { GetPixelScaleOptions, ImageDataLike, ImageDataLikeData } from './types.js';
 
 function isMatchingColor(rgbaA: number[], rgbaB: number[], maxColorDiff: number) {
   return rgbaA.every((rgba, i) => {
@@ -91,8 +91,9 @@ function isValidScale(imageData: ImageDataLike, scale: number, maxColorDiff: num
 
 export function getPixelScale(
   imageData: ImageDataLike,
-  { maxColorDiff = 0 }: GetPixelScaleOptions = {}
+  options?: GetPixelScaleOptions | undefined | null
 ): number {
+  const { maxColorDiff = 0 } = options || {};
   const { width, height } = imageData;
   const possibleScales = findCommonDivisors(width, height);
 
@@ -100,9 +101,9 @@ export function getPixelScale(
   // then we cannot correctly determine the pixel scale
   if (findCommonDivisors.length === 1) {
     return 1;
-  } else {
-    possibleScales.shift();
   }
+
+  possibleScales.shift();
 
   // start from largest divisor, since it's more efficient
   // and we want to find the highest possible pixel scale

--- a/src/helpers/imageData.ts
+++ b/src/helpers/imageData.ts
@@ -1,4 +1,4 @@
-import { ImageDataLike } from '../types.js';
+import type { ImageDataLike } from '../types.js';
 
 export function isValidImageData(imageData: ImageDataLike): imageData is ImageDataLike {
   return !!(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export { getPixelScale } from './getPixelScale.js';
-export { scalePixels } from './scalePixels.js';
+export { scalePixels, multiplyPixelScale, dividePixelScale } from './scalePixels.js';
 export * from './types.js';

--- a/src/scalePixels.test.ts
+++ b/src/scalePixels.test.ts
@@ -1,78 +1,124 @@
 import IsomorphicImageData from '@canvas/image-data';
-import { beforeAll, expect, it } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import {
   getPixelTheCatScale1,
-  getPixelTheCatScale32,
   getPixelTheCatScale5,
+  getPixelTheCatScale32,
 } from '../test/testImageData.js';
-import { scalePixels } from './scalePixels.js';
+import { getPixelScale } from './getPixelScale.js';
+import { scalePixels, dividePixelScale, multiplyPixelScale } from './scalePixels.js';
 
 global.ImageData = IsomorphicImageData as any;
 
-let pixelScale1: ImageData;
-let pixelScale5: ImageData;
-let pixelScale32: ImageData;
+const testImageData: Record<string | number, ImageData> = {};
 
 beforeAll(async () => {
-  pixelScale1 = await getPixelTheCatScale1();
-  pixelScale5 = await getPixelTheCatScale5();
-  pixelScale32 = await getPixelTheCatScale32();
+  const [p1, p5, p32] = await Promise.all([
+    getPixelTheCatScale1(),
+    getPixelTheCatScale5(),
+    getPixelTheCatScale32(),
+  ]);
+  testImageData[1] = p1;
+  testImageData[5] = p5;
+  testImageData[32] = p32;
 });
 
-it('upscales pixels', async () => {
-  let expected: ImageData;
-  let result: ImageData;
+describe(scalePixels.name, () => {
+  it('upscales pixels', async () => {
+    let expected: ImageData;
+    let result: ImageData;
 
-  // x1 to x5
-  expected = pixelScale5;
-  result = scalePixels(pixelScale1, 5, { from: 1 });
-  expect(result.data.length).toEqual(expected.width * expected.height * 4);
-  expect(result.data.join()).toEqual(expected.data.join());
-  expect(result.width).toBe(expected.width);
-  expect(result.height).toBe(expected.height);
+    // x1 to x5
+    expected = testImageData[5];
+    result = scalePixels(testImageData[1], 5, { from: 1 });
+    expect(result.data.length).toEqual(expected.width * expected.height * 4);
+    expect(result.data.join()).toEqual(expected.data.join());
+    expect(result.width).toBe(expected.width);
+    expect(result.height).toBe(expected.height);
 
-  // x1 to x32
-  expected = pixelScale32;
-  result = scalePixels(pixelScale1, 32, { from: 1 });
-  expect(result.data.length).toEqual(expected.width * expected.height * 4);
-  expect(result.data.join()).toEqual(expected.data.join());
-  expect(result.width).toBe(expected.width);
-  expect(result.height).toBe(expected.height);
+    // x1 to x32
+    expected = testImageData[32];
+    result = scalePixels(testImageData[1], 32, { from: 1 });
+    expect(result.data.length).toEqual(expected.width * expected.height * 4);
+    expect(result.data.join()).toEqual(expected.data.join());
+    expect(result.width).toBe(expected.width);
+    expect(result.height).toBe(expected.height);
 
-  // x5 to x32
-  expected = pixelScale32;
-  result = scalePixels(pixelScale5, 32, { from: 5 });
-  expect(result.data.length).toEqual(expected.width * expected.height * 4);
-  expect(result.data.join()).toEqual(expected.data.join());
-  expect(result.width).toBe(expected.width);
-  expect(result.height).toBe(expected.height);
+    // x5 to x32
+    expected = testImageData[32];
+    result = scalePixels(testImageData[5], 32, { from: 5 });
+    expect(result.data.length).toEqual(expected.width * expected.height * 4);
+    expect(result.data.join()).toEqual(expected.data.join());
+    expect(result.width).toBe(expected.width);
+    expect(result.height).toBe(expected.height);
+  });
+
+  it('downscales pixels', async () => {
+    let expected: ImageData;
+    let result: ImageData;
+
+    // x32 to x5
+    expected = testImageData[5];
+    result = scalePixels(testImageData[32], 5, { from: 32 });
+    expect(result.data.length).toEqual(expected.width * expected.height * 4);
+    expect(result.data.join()).toEqual(expected.data.join());
+    expect(result.width).toBe(expected.width);
+    expect(result.height).toBe(expected.height);
+
+    // x32 to x1
+    expected = testImageData[1];
+    result = scalePixels(testImageData[32], 1, { from: 32 });
+    expect(result.data.length).toEqual(expected.width * expected.height * 4);
+    expect(result.data.join()).toEqual(expected.data.join());
+    expect(result.width).toBe(expected.width);
+    expect(result.height).toBe(expected.height);
+
+    // x5 to x1
+    expected = testImageData[1];
+    result = scalePixels(testImageData[5], 1, { from: 5 });
+    expect(result.data.length).toEqual(expected.width * expected.height * 4);
+    expect(result.data.join()).toEqual(expected.data.join());
+    expect(result.width).toBe(expected.width);
+    expect(result.height).toBe(expected.height);
+  });
 });
 
-it('downscales pixels', async () => {
-  let expected: ImageData;
-  let result: ImageData;
+describe(multiplyPixelScale.name, () => {
+  it.each([
+    { startScale: 1, times: 8 },
+    { startScale: 5, times: 6 },
+    { startScale: 32, times: 3 },
+  ])('multiplies pixel scale (from: $startScale, times: $times)', async ({ startScale, times }) => {
+    const imageData = await testImageData[startScale];
+    const imageScale = getPixelScale(imageData);
+    const expectedScale = times * imageScale;
+    const expectedHeight = imageData.height * times;
+    const expectedWidth = imageData.width * times;
 
-  // x32 to x5
-  expected = pixelScale5;
-  result = scalePixels(pixelScale32, 5, { from: 32 });
-  expect(result.data.length).toEqual(expected.width * expected.height * 4);
-  expect(result.data.join()).toEqual(expected.data.join());
-  expect(result.width).toBe(expected.width);
-  expect(result.height).toBe(expected.height);
+    const result = multiplyPixelScale(imageData, times);
 
-  // x32 to x1
-  expected = pixelScale1;
-  result = scalePixels(pixelScale32, 1, { from: 32 });
-  expect(result.data.length).toEqual(expected.width * expected.height * 4);
-  expect(result.data.join()).toEqual(expected.data.join());
-  expect(result.width).toBe(expected.width);
-  expect(result.height).toBe(expected.height);
+    expect(getPixelScale(result)).toBe(expectedScale);
+    expect(result.height).toBe(expectedHeight);
+    expect(result.width).toBe(expectedWidth);
+  });
+});
 
-  // x5 to x1
-  expected = pixelScale1;
-  result = scalePixels(pixelScale5, 1, { from: 5 });
-  expect(result.data.length).toEqual(expected.width * expected.height * 4);
-  expect(result.data.join()).toEqual(expected.data.join());
-  expect(result.width).toBe(expected.width);
-  expect(result.height).toBe(expected.height);
+describe(dividePixelScale.name, () => {
+  it.each([
+    { startScale: 1, times: 8 },
+    { startScale: 5, times: 6 },
+    { startScale: 32, times: 3 },
+  ])('divides pixel scale (from: $startScale, times: $times)', async ({ startScale, times }) => {
+    const imageData = await testImageData[startScale];
+    const imageScale = getPixelScale(imageData);
+    const expectedScale = times * imageScale;
+    const expectedHeight = imageData.height * times;
+    const expectedWidth = imageData.width * times;
+
+    const result = multiplyPixelScale(imageData, times);
+
+    expect(getPixelScale(result)).toBe(expectedScale);
+    expect(result.height).toBe(expectedHeight);
+    expect(result.width).toBe(expectedWidth);
+  });
 });

--- a/src/scalePixels.ts
+++ b/src/scalePixels.ts
@@ -1,11 +1,12 @@
 import { getPixelScale } from './getPixelScale.js';
-import { ScalePixelsOptions } from './types.js';
+import type { ScalePixelsOptions } from './types.js';
 
 export function scalePixels(
   imageData: ImageData,
   to: number,
-  { from, maxColorDiff }: ScalePixelsOptions
+  options?: ScalePixelsOptions | undefined | null
 ): ImageData {
+  const { from, maxColorDiff } = options || {};
   const { data, width, height } = imageData;
   const currentScale = from || getPixelScale(imageData, { maxColorDiff: maxColorDiff || 0 });
   const dataLength = data.length;

--- a/src/scalePixels.ts
+++ b/src/scalePixels.ts
@@ -37,3 +37,23 @@ export function scalePixels(
 
   return new ImageData(Uint8ClampedArray.from(newData), newWidth, newHeight);
 }
+
+export function multiplyPixelScale(
+  imageData: ImageData,
+  by: number,
+  options?: ScalePixelsOptions | undefined | null
+) {
+  const scale = getPixelScale(imageData, options);
+  const to = scale * by;
+  return scalePixels(imageData, to, options);
+}
+
+export function dividePixelScale(
+  imageData: ImageData,
+  by: number,
+  options?: ScalePixelsOptions | undefined | null
+) {
+  const scale = getPixelScale(imageData, options);
+  const to = scale / by;
+  return scalePixels(imageData, to, options);
+}


### PR DESCRIPTION
The concept of pixel scale isn't super clear, and you usually just want to e.g. upscale or downscale an image by a multiplier. Adding helper functions for this should make the operation a bit more accessible and the package easier to understand.